### PR TITLE
Fixed App.js _SOCKET_HOST and _SOCKET_PORT unused

### DIFF
--- a/App.js
+++ b/App.js
@@ -129,8 +129,8 @@ const App: () => Node = () => {
         return await new Promise(() => {
             setString('_FLEETBASE_KEY', key);
             setString('_FLEETBASE_HOST', host);
-            setString('_SOCKET_HOST', socketcluster_host);
-            setString('_SOCKET_PORT', socketcluster_port);
+            setString('_SOCKETCLUSTER_HOST', socketcluster_host);
+            setString('_SOCKETCLUSTER_PORT', socketcluster_port);
 
             if (navigationRef.current) {
                 navigationRef.current.reset({


### PR DESCRIPTION
 in main App.js, in setFleetbaseConfig, socketcluster_host and socketcluster_port were stored on _SOCKET_HOST and _SOCKET_PORT entries, but later in /features/shared/ConfigScreen.js the values retrieved are _SOCKETCLUSTER_HOST and _SOCKETCLUSTER_PORT, so those external link parameters were never used. This results in a mixed setting, and login with private deployment is not working using the link.