### PR TITLE
Fix POD photo resizing to use image dimensions instead of screen size

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,5 @@
 import Config from 'react-native-config';
-import { Platform, ActionSheetIOS, Alert, Dimensions } from 'react-native';
+import { Platform, ActionSheetIOS, Alert, Image } from 'react-native';
 import { Collection, lookup } from '@fleetbase/sdk';
 import storage, { getString } from './storage';
 import { capitalize } from './format';
@@ -11,10 +11,27 @@ import { parseISO } from 'date-fns';
 import NavigatorConfig from '../../navigator.config';
 import ImageResizer from '@bam.tech/react-native-image-resizer';
 
+// Image.getSize is callback based, so wrap it to be awaitable. Resolves null
+// instead of rejecting so callers can decide how to degrade, matching how the
+// other promise wrappers in this app handle failure.
+function getImageSize(uri: string): Promise<{ width: number, height: number } | null> {
+    return new Promise((resolve) => {
+        Image.getSize(uri, (width, height) => resolve({ width, height }), () => resolve(null));
+    });
+}
+
 export async function resizePhoto(uri: string, maxSize = 1024): Promise<string> {
     const MAX_DIMENSION = maxSize;
 
-    const { width, height } = Dimensions.get('window');
+    // Measure the photo itself, not the device screen
+    const size = await getImageSize(uri);
+
+    // If the image can't be read, upload it as-is rather than lose the photo
+    if (!size) {
+        return uri;
+    }
+
+    const { width, height } = size;
     // preserve aspect ratio
     const ratio = Math.min(MAX_DIMENSION / width, MAX_DIMENSION / height, 1);
 


### PR DESCRIPTION
### Problem

`resizePhoto` in `src/utils/index.js` measured the **device screen** instead of the image it was given:

```js
const { width, height } = Dimensions.get('window');
```

The `uri` argument — the actual photo — was never measured. Every captured photo was scaled to the phone's point size and forced into the screen's aspect ratio, so proof-of-delivery uploads came out at a fraction of their real resolution.

On an iPhone 14 (390×844pt) with a 12MP capture (4032×3024):

| | Output | Aspect ratio |
|---|---|---|
| Before | 390 × 844 | 0.46 (portrait — wrong) |
| After | 1024 × 768 | 1.333 (matches source) |

That's ~2.4× more pixels by raw dimensions, and closer to 7× once `mode: 'contain'` fits a landscape photo into that portrait box.

### Fix

Read the real dimensions with `Image.getSize`, wrapped as a promise. Following the existing convention in `src/utils/location.js`, the wrapper resolves `null` on failure rather than rejecting — and `resizePhoto` then returns the original `uri`, so an unreadable image uploads at full size instead of being lost.

The `Math.min(..., 1)` clamp is unchanged, so images already under `maxSize` are still passed through untouched (verified: 800×600 stays 800×600).

### Notes

- **Not tested on a physical device.** The resize math is verified, but the change isn't exercised through the POD flow — worth confirming `Image.getSize` resolves for local `file://` paths on Android in particular.
- **CI will likely fail here.** The workflow builds `.env` from repo secrets, and GitHub doesn't expose those to pull requests from forks. Unrelated to this change.
- Scope kept deliberately narrow. `ImageResizer.createResizedImage` has no `try`/`catch`, so one bad photo rejects the whole `Promise.all` batch in `ProofOfDeliveryScreen`. Happy to file that separately.

Fixes #89
